### PR TITLE
Preprocessing text for Vulyk with NER model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ target/
 _static/
 tasks/
 done/
+.idea
+.ipynb_checkpoints

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ python3 -m unittest discover -s test
 ### Preprocess plain text and format it into Vulyk JSON
 This will tokenize text, perform NER search and output results into Vulyk compatible json format.
 
+Required dependencies
+```shell
+pip3 install stanza
+```
+
 ```shell
 cat file.txt | python3 convert2vulyk.py > save_to_file.json
 ```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# NER tagging plugin for Vulyk, crowdsourcing framework
+
+To connect plugin to Vulyk:
+1. Install this plugin as pip package `pip install git+https://github.com/lang-uk/vulyk-ner.git`
+2. Make sure to include configuration for it in `local_settings.py`
+```python
+ENABLED_TASKS = {
+    # other plugins will be somewhere here
+    'vulyk_ner': 'NERTaggingTaskType'
+}
+```
+
+Full installation instructions can be found here https://github.com/mrgambal/vulyk
+
+Running tests after you made changes
+```shell
+python3 -m unittest discover -s test
+```
+
+## Conversion utils included
+
+### Preprocess plain text and format it into Vulyk JSON
+This will tokenize text, perform NER search and output results into Vulyk compatible json format.
+
+```shell
+cat file.txt | python3 convert2vulyk.py > save_to_file.json
+```
+
+Import to Vulyk 
+```shell
+./manage.py db load ner_tagging_task --batch batch_name ./path/save_to_file.json
+```
+
+You can also convert to vulyk json an already annotated text (Brat format only):
+```shell
+python3 convert2vulyk.py --brat_annotation annotation.ann > save_to_file.json
+```
+
+For more details and possible parameters refer to `python3 convert2vulyk.py -h`
+

--- a/README.rst
+++ b/README.rst
@@ -1,2 +1,0 @@
-# vulyk-ner
-NER tagging plugin for Vulyk, crowdsourcing framework

--- a/bin/convert2vulyk.py
+++ b/bin/convert2vulyk.py
@@ -1,0 +1,155 @@
+#!env python
+
+import argparse
+import json
+import logging
+import re
+import sys
+import time
+from collections import namedtuple
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.ERROR)
+
+BsfInfo = namedtuple('BsfInfo', 'id, tag, start_idx, end_idx, token')
+
+
+def parse_bsf(bsf_data: str) -> list:
+    """
+    Convert multiline textual bsf representation to a list of named entities.
+
+    :param bsf_data: data in the format 'T9	PERS 778 783    токен'. Can be multiple lines.
+    :return: list of named tuples for each line of the data representing a single named entity token
+    """
+    if len(bsf_data.strip()) == 0:
+        return []
+
+    ln_ptrn = re.compile(r'(T\d+)\s(\w+)\s(\d+)\s(\d+)\s(.+?)(?=T\d+\s\w+\s\d+\s\d+|$)', flags=re.DOTALL)
+    result = []
+    for m in ln_ptrn.finditer(bsf_data.strip()):
+        bsf = BsfInfo(m.group(1), m.group(2), int(m.group(3)), int(m.group(4)), m.group(5).strip())
+        result.append(bsf)
+    return result
+
+
+def convert_bsf_2_vulyk(text: str, bsf_markup: str) -> dict:
+    """
+    Given tokenized text and named entities in Brat standoff format, generate object
+    in the format compatible with Vulyk markup tool.
+    :param text: tokenized text (space as separator)
+    :param bsf_markup: named entities in Brat standoff format
+    :return: dict that can be directly converted to Vulyk json file
+    """
+    bsf = parse_bsf(bsf_markup)
+    ents = [[e.id, e.tag, [[e.start_idx, e.end_idx]]] for e in bsf]
+
+    idx = 0
+    t_idx = 0
+    s_offsets = []
+    t_offsets = []
+    if len(text) > 0:
+        for s in text.split('\n'):
+            s_offsets.append([idx, idx + len(s)])
+            for t in s.strip().split(' '):
+                t_offsets.append([t_idx, t_idx + len(t)])
+                t_idx += len(t) + 1
+
+            idx += len(s) + 1
+            t_idx = idx
+
+    ts = int(time.time())
+    vulyk = {"modifications": [], "equivs": [], "protocol": 1, "ctime": ts, "triggers": [], "text": text,
+              "source_files": ["ann", "txt"], "messages": [], "sentence_offsets": s_offsets, "comments": [],
+              "entities": ents, "mtime": ts, "relations": [], "token_offsets": t_offsets, "action": "getDocument",
+              "normalizations": [], "attributes": [], "events": [], "document": "", "collection": "/"}
+
+    return vulyk
+
+
+def text_2_vulyk(text: str, bsf_markup: str = None) -> str:
+    """
+    Convert text string with annotations to json string for Vulyk annotation tool.
+    If annotations are provided in bsf_markup then text must be tokenized. Otherwise a raw text string can be supplied.
+    :param text: tokenzied OR raw text string
+    :param bsf_markup: string containing annotations in brat standoff format
+    :return: json string compatible with Vulyk (Brat annotation tool)
+    """
+    txt = text
+    markup = bsf_markup
+    if bsf_markup is None:
+        log.info("No markup file => processing text with Stanza to extract Named Entities.")
+        # run tokenization and NER
+        from tokenize_uk import tokenize_text
+        token_list = tokenize_text(text)
+        # we have list<paragraphs> of list<sentences> of list<tokens>
+        paragraph = ['\n'.join([' '.join(t) for t in sent]) for sent in token_list]
+        txt = '\n'.join(paragraph)  # stanza bug does not allow for double new line symbol right now
+        log.debug(txt)
+
+        markup = _run_ner(txt)
+        log.debug(markup)
+
+    vulyk_obj = convert_bsf_2_vulyk(txt, markup)
+
+    return json.dumps(vulyk_obj, ensure_ascii=False)
+
+
+def _run_ner(txt: str) -> str:
+    """
+    Run ner pipeline on tokenized text using Stanza.
+    :param txt: tokenized text string
+    :return: string with annotations in brat standoff format
+    """
+    import stanza
+    logging.getLogger("stanza").setLevel(log.level)
+
+    stanza.download('uk')
+
+    ner = stanza.Pipeline(lang='uk', processors='tokenize,mwt,ner', tokenize_pretokenized='true')
+    log.info("Processing text. It may take few seconds...")
+    doc = ner(txt)
+
+    tok_i = 1
+    brat_str = ""
+    for ent in doc.ents:
+        brat_str += f'T{tok_i}\t{ent.type} {ent.start_char} {ent.end_char}\t{ent.text}\n'
+        tok_i += 1
+    return brat_str
+
+
+if __name__ == "__main__":
+    logging.basicConfig()
+
+    parser = argparse.ArgumentParser(
+        description='Convert text (tokenized or generic) to json file supported by Vulyk. '
+                    'Data file can be supplied via cmd line arguments '
+                    'or you can pipe data in and out of this script like:'
+                    '`cat file.txt | python3 convert2vulyk.py > save_to_file.json`')
+    parser.add_argument('text_file', nargs="?", type=argparse.FileType('r'), default=sys.stdin,
+                        help='Text file to process. If file path not provided, assumes stdin stream.'
+                             ' Must be tokenized if --brat_file is provided. '
+                             '*.ann for lang-uk data set')
+    parser.add_argument('--brat_annotation', type=argparse.FileType('r'), default=None,
+                        help='Path to file with Brat standoff markup')
+    parser.add_argument('-v', action='store_true', help='Print more logs (info)')
+    parser.add_argument('-vv', action='store_true', help='Print even more logs (debug)')
+
+    args = parser.parse_args()
+
+    if args.vv:
+        log.setLevel(logging.DEBUG)
+    elif args.v:
+        log.setLevel(logging.INFO)
+
+    brat_markup = None
+    if args.brat_annotation is not None:  # read markup
+        log.info(f"Reading markup from file")
+        brat_markup = args.brat_annotation.read()
+        log.debug(brat_markup)
+    else:
+        log.info(f"No markup file is provided. Assuming a raw text as input.")
+
+    text_data = args.text_file.read()
+
+    vulyk_json = text_2_vulyk(text_data, brat_markup)
+    print(vulyk_json)

--- a/bin/convert2vulyk.py
+++ b/bin/convert2vulyk.py
@@ -21,12 +21,14 @@ def parse_bsf(bsf_data: str) -> list:
     :param bsf_data: data in the format 'T9	PERS 778 783    токен'. Can be multiple lines.
     :return: list of named tuples for each line of the data representing a single named entity token
     """
-    if len(bsf_data.strip()) == 0:
+    data = bsf_data.strip()
+    if not data:
         return []
-
+    #                     Token_id Entity start  end    text within range
+    #                        \/      \/     \/    \/      \/
     ln_ptrn = re.compile(r'(T\d+)\s(\w+)\s(\d+)\s(\d+)\s(.+?)(?=T\d+\s\w+\s\d+\s\d+|$)', flags=re.DOTALL)
     result = []
-    for m in ln_ptrn.finditer(bsf_data.strip()):
+    for m in ln_ptrn.finditer(data):
         bsf = BsfInfo(m.group(1), m.group(2), int(m.group(3)), int(m.group(4)), m.group(5).strip())
         result.append(bsf)
     return result
@@ -47,7 +49,7 @@ def convert_bsf_2_vulyk(text: str, bsf_markup: str) -> dict:
     t_idx = 0
     s_offsets = []
     t_offsets = []
-    if len(text) > 0:
+    if text:
         for s in text.split('\n'):
             s_offsets.append([idx, idx + len(s)])
             for t in s.strip().split(' '):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 glob2==0.7
+tokenize_uk

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-with open('README.rst') as readme_file:
+with open('README.md') as readme_file:
     readme = readme_file.read()
 
 with open('HISTORY.rst') as history_file:

--- a/test/test_bsf_2_vulyk.py
+++ b/test/test_bsf_2_vulyk.py
@@ -1,0 +1,74 @@
+import time
+import unittest
+
+from bin.convert2vulyk import convert_bsf_2_vulyk
+
+
+class TestBsf2Vulyk(unittest.TestCase):
+    def setUp(self) -> None:
+        self.vulyk_base = {
+            "modifications": [ ],
+            "equivs": [ ],
+            "protocol": 1,
+            "ctime": int(time.time()),
+            "triggers": [ ],
+            "text": "",
+            "source_files": ["ann", "txt" ],
+            "messages": [ ],
+            "sentence_offsets": [],
+            "comments": [ ],
+            "entities": [],
+            "mtime": int(time.time()),
+            "relations": [ ],
+            "token_offsets": [],
+            "action": "getDocument",
+            "normalizations": [ ],
+            "attributes": [ ],
+            "events": [ ],
+            "document": "",
+            "collection": "/"
+        }
+
+    def test_empty_vulyk(self):
+        data = ''
+        bsf_markup = ''
+        expected = self.vulyk_base
+        self.assertEqual(expected, convert_bsf_2_vulyk(data, bsf_markup))
+
+    def test_no_ents(self):
+        data = 'Текст без сутностей'
+        bsf_markup = ''
+        self.vulyk_base["text"] = data
+        self.assertEqual([], convert_bsf_2_vulyk(data, bsf_markup)["entities"])
+
+    def test_tok_idx(self):
+        data = """розпорядження землями
+в межах , визначених"""
+        bsf_markup = ""
+        tok_idx = [[0, 13], [14, 21],
+                   [22, 23], [24, 29], [30, 31], [32, 42]]
+        self.vulyk_base["text"] = data
+        self.assertEqual(tok_idx, convert_bsf_2_vulyk(data, bsf_markup)["token_offsets"])
+
+    def test_sentence_offset(self):
+        data = """Речення номер 1 .
+
+Рядок другий"""
+        bsf_markup = ""
+        sent_idx = [[0, 17], [18, 18], [19, 31]]
+        result = convert_bsf_2_vulyk(data, bsf_markup)
+        self.assertEqual(sent_idx, result["sentence_offsets"])
+        self.assertEqual([], result["entities"])
+
+    def test_entities_offset(self):
+        data = """Речення з Токен . 
+токен Другий """
+        bsf_markup = """T1 ORG 11 15 Токен
+T2 MISC 25 31 Другий"""
+        expected = [["T1", "ORG", [[11, 15]]], ["T2", "MISC", [[25, 31]]]]
+        result = convert_bsf_2_vulyk(data, bsf_markup)
+        self.assertEqual(expected, result["entities"])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- script to tokenize, ner, and convert to Vulyk JSON file of plain text using Stanza NER model for now
- ability to convert tokenized text with brat .ann annotations to vulyk ner
- basic tests to cover conversion logic

Known issues:
Stanza has a bug with pretokenized text (presumably) that collapses multiple '\n' symbols into one and so breaks the markup of the document. This is not ideal in scenarios where we need to separate paragraphs with multiple new-lines.

Stanza is not included in requirements.txt to avoid pulling it as a dependency during plugin installation. 